### PR TITLE
Improve ToArray trait type annotations for better static analysis

### DIFF
--- a/src/Trait/ToArray.php
+++ b/src/Trait/ToArray.php
@@ -17,6 +17,8 @@ trait ToArray
 {
     /**
      * @return array<string, int|string>
+     *
+     * @phpstan-return ($this is \BackedEnum ? array<string, string|int> : array<string, string>)
      */
     public static function toArray(): array
     {


### PR DESCRIPTION
Add conditional return type annotations to distinguish between BackedEnum and UnitEnum return types. This helps PHPStan and other static analysis tools better understand the actual return types.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
